### PR TITLE
Fix native method check

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,8 @@
  * </pre></code>
  */
 export function patch() {
-    if (
-        typeof ShadowRoot !== 'undefined' &&
-        typeof ShadowRoot.getSelection === 'undefined'
-    ) {
-        ShadowRoot.prototype.getSelection = function() {
+    if (typeof ShadowRoot !== 'undefined') {
+        ShadowRoot.prototype.getSelection = ShadowRoot.prototype.getSelection || function() {
             return document.getSelection();
         };
     }


### PR DESCRIPTION
Polyfill used to override method even when it already exists due to invalid check of static method instead of prototype.